### PR TITLE
Change return type of quote route to json object

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, render_template
+from flask import Flask, request, render_template, jsonify
 import yfinance as yf
 
 # instantiate the Flask app.
@@ -15,7 +15,7 @@ def display_quote():
 	quote = yf.Ticker(symbol)
 
 	#return the object via the HTTP Response
-	return quote.info
+	return jsonify(quote.info)
 
 # API route for pulling the stock history
 @app.route("/history")


### PR DESCRIPTION
While following your tutorial and implementing the flask application I got the error below. Turned out that Flask had some trouble with returning the plain `dict` from the `/quote` route. In this pull request I simply jsonify the return value and everything worked as expected.


```
127.0.0.1 - - [02/Mar/2021 20:41:09] "GET /quote?symbol=MSFT&_=1614714065971 HTTP/1.1" 500 -
Traceback (most recent call last):
  File "C:\Users\rikkr\Anaconda3\lib\site-packages\flask\app.py", line 1993, in make_response
    rv = self.response_class.force_type(rv, request.environ)
  File "C:\Users\rikkr\Anaconda3\lib\site-packages\werkzeug\wrappers\base_response.py", line 269, in force_type
    response = BaseResponse(*_run_wsgi_app(response, environ))
  File "C:\Users\rikkr\Anaconda3\lib\site-packages\werkzeug\wrappers\base_response.py", line 26, in _run_wsgi_app
    return _run_wsgi_app(*args)
  File "C:\Users\rikkr\Anaconda3\lib\site-packages\werkzeug\test.py", line 1119, in run_wsgi_app
    app_rv = app(environ, start_response)
TypeError: 'dict' object is not callable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\rikkr\Anaconda3\lib\site-packages\flask\app.py", line 2328, in __call__
    return self.wsgi_app(environ, start_response)
  File "C:\Users\rikkr\Anaconda3\lib\site-packages\flask\app.py", line 2314, in wsgi_app
    response = self.handle_exception(e)
  File "C:\Users\rikkr\Anaconda3\lib\site-packages\flask\app.py", line 1760, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "C:\Users\rikkr\Anaconda3\lib\site-packages\flask\_compat.py", line 36, in reraise
    raise value
  File "C:\Users\rikkr\Anaconda3\lib\site-packages\flask\app.py", line 2311, in wsgi_app
    response = self.full_dispatch_request()
  File "C:\Users\rikkr\Anaconda3\lib\site-packages\flask\app.py", line 1835, in full_dispatch_request
    return self.finalize_request(rv)
  File "C:\Users\rikkr\Anaconda3\lib\site-packages\flask\app.py", line 1850, in finalize_request
    response = self.make_response(rv)
  File "C:\Users\rikkr\Anaconda3\lib\site-packages\flask\app.py", line 2001, in make_response
    reraise(TypeError, new_error, sys.exc_info()[2])
  File "C:\Users\rikkr\Anaconda3\lib\site-packages\flask\_compat.py", line 35, in reraise
    raise value.with_traceback(tb)
  File "C:\Users\rikkr\Anaconda3\lib\site-packages\flask\app.py", line 1993, in make_response
    rv = self.response_class.force_type(rv, request.environ)
  File "C:\Users\rikkr\Anaconda3\lib\site-packages\werkzeug\wrappers\base_response.py", line 269, in force_type
    response = BaseResponse(*_run_wsgi_app(response, environ))
  File "C:\Users\rikkr\Anaconda3\lib\site-packages\werkzeug\wrappers\base_response.py", line 26, in _run_wsgi_app
    return _run_wsgi_app(*args)
  File "C:\Users\rikkr\Anaconda3\lib\site-packages\werkzeug\test.py", line 1119, in run_wsgi_app
    app_rv = app(environ, start_response)
TypeError: 'dict' object is not callable
The view function did not return a valid response. The return type must be a string, tuple, Response instance, or WSGI callable, but it was a dict.
```